### PR TITLE
fix(stop-hook): fix EVALUATIVE_DESIGN_TELLS comment and add evidence normalization tests

### DIFF
--- a/scripts/hallucination-audit-stop.cjs
+++ b/scripts/hallucination-audit-stop.cjs
@@ -142,7 +142,7 @@ const EVIDENCE_MARKERS = [
 const BACKTICK_RE = /`[^`\n]+`/; // inline code — tested against raw (pre-strip) text
 
 // Evaluative design tell phrases — exact multi-word phrases only; near-zero false-positive risk.
-// The `g` flag is required so the while-loop in findTriggerMatches() can iterate all occurrences.
+// The `g` flag is required so the for...of loop in findTriggerMatches() can iterate all occurrences.
 const EVALUATIVE_DESIGN_TELLS =
   /\b(?:the\s+cleanest\s+fix|the\s+simplest\s+fix|cleanest\s+solution|simplest\s+solution|cleanest\s+approach|simplest\s+approach|the\s+obvious\s+fix|the\s+obvious\s+solution)\b/gi;
 

--- a/tests/hallucination-audit-stop.test.cjs
+++ b/tests/hallucination-audit-stop.test.cjs
@@ -813,6 +813,32 @@ describe('block reason self-trigger regression', () => {
     }
   });
 
+  it('normalizes embedded newlines in evidence to single spaces', () => {
+    const matches = [{ kind: 'speculation_language', evidence: 'the\ncleanest\nfix', offset: 0 }];
+    const reason = buildBlockReason(matches);
+    // The evidence line is the second line of the "Detected trigger language" section.
+    // Extract just that line to confirm newlines were collapsed before wrapping in backticks.
+    const evidenceLine = reason.split('\n').find((l) => l.startsWith('- speculation_language:'));
+    expect(evidenceLine).toBeDefined();
+    expect(evidenceLine).toContain('`the cleanest fix`');
+    expect(evidenceLine).not.toContain('\n');
+  });
+
+  it('escapes embedded backticks in evidence to prevent breaking inline code span', () => {
+    const matches = [{ kind: 'speculation_language', evidence: 'the `cleanest` fix', offset: 0 }];
+    const reason = buildBlockReason(matches);
+    // Extract just the evidence line — the static instruction text must not interfere.
+    const evidenceLine = reason.split('\n').find((l) => l.startsWith('- speculation_language:'));
+    expect(evidenceLine).toBeDefined();
+    // Backticks replaced with single quotes so the span is a single inline-code token.
+    expect(evidenceLine).toContain("`the 'cleanest' fix`");
+    // The evidence span must open and close exactly once: one ` at start, one ` at end.
+    const span = evidenceLine.replace(/^- speculation_language: /, '');
+    expect(span.startsWith('`')).toBe(true);
+    expect(span.endsWith('`')).toBe(true);
+    expect(span.slice(1, -1)).not.toContain('`');
+  });
+
   it('full reason string with one match per category does not re-trigger findTriggerMatches', () => {
     // Self-maintaining canary: if anyone adds a bare trigger word to the static
     // instruction text or changes the evidence snippet format so it is no longer


### PR DESCRIPTION
## Summary

- Corrects stale comment at line 145 of `scripts/hallucination-audit-stop.cjs`: `while-loop` → `for...of loop` to match the actual `matchAll()` iteration pattern in `findTriggerMatches()`.
- Adds two regression tests inside `describe('block reason self-trigger regression')` verifying that `buildBlockReason()` collapses embedded newlines and replaces embedded backticks in evidence snippets; assertions are scoped to the evidence line rather than the full reason string to prevent false failures from static instruction text.

## Test plan

- [ ] `pnpm test` — 302 tests pass, 0 failures
- [ ] `npx biome check .` — 31 files checked, no fixes applied
- [ ] Both new tests (`normalizes embedded newlines in evidence to single spaces`, `escapes embedded backticks in evidence to prevent breaking inline code span`) appear in the passing list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests verifying that embedded newlines in evidence are normalized to single spaces in generated output.
  * Added tests ensuring backticks within evidence are properly escaped to maintain well-formed inline code formatting.

* **Chores**
  * Updated code comment for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->