### PR TITLE
fix(stop-hook): guard matchAll g-flag and add evaluative-design regression tests

### DIFF
--- a/scripts/hallucination-audit-stop.cjs
+++ b/scripts/hallucination-audit-stop.cjs
@@ -483,8 +483,13 @@ function findTriggerMatches(text) {
   // These phrases assert a conclusion ("cleanest", "simplest", "obvious") on a
   // proposed change without evidence. The regex canary fires on exact multi-word
   // phrases with near-zero false-positive risk.
-  // matchAll() requires the `g` flag on EVALUATIVE_DESIGN_TELLS (set at definition site).
-  for (const edcMatch of haystack.matchAll(EVALUATIVE_DESIGN_TELLS)) {
+  // Ensure we always pass a global regex into matchAll(), even if the base
+  // EVALUATIVE_DESIGN_TELLS definition is missing the `g` flag.
+  const edcFlags = EVALUATIVE_DESIGN_TELLS.flags.includes('g')
+    ? EVALUATIVE_DESIGN_TELLS.flags
+    : `${EVALUATIVE_DESIGN_TELLS.flags}g`;
+  const edcGlobal = new RegExp(EVALUATIVE_DESIGN_TELLS.source, edcFlags);
+  for (const edcMatch of haystack.matchAll(edcGlobal)) {
     if (isIndexWithinQuestion(haystack, edcMatch.index)) continue;
     matches.push({ kind: 'evaluative_design_claim', evidence: edcMatch[0].trim() });
   }

--- a/tests/hallucination-audit-stop.test.cjs
+++ b/tests/hallucination-audit-stop.test.cjs
@@ -699,6 +699,18 @@ describe('evaluative_design_claim', () => {
     const edcMatches = matches.filter((m) => m.kind === 'evaluative_design_claim');
     expect(edcMatches.length).toBe(0);
   });
+
+  it('detects multiple evaluative_design_claim occurrences in one text', () => {
+    const matches = findTriggerMatches('The cleanest fix is X. The simplest approach is Y.');
+    const edcMatches = matches.filter((m) => m.kind === 'evaluative_design_claim');
+    expect(edcMatches.length).toBe(2);
+  });
+
+  it('suppresses evaluative_design_claim inside a question', () => {
+    const matches = findTriggerMatches('Is the simplest fix really appropriate?');
+    const edcMatches = matches.filter((m) => m.kind === 'evaluative_design_claim');
+    expect(edcMatches.length).toBe(0);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
- Defensive g-flag guard for EVALUATIVE_DESIGN_TELLS.matchAll() call site
- Tests for multiple occurrences and question-form suppression