### PR TITLE
feat(scripts): add run wait and fix pr merge --auto

### DIFF
--- a/.claude/scripts/gh-api.cjs
+++ b/.claude/scripts/gh-api.cjs
@@ -486,6 +486,25 @@ async function prMerge(octokit, prStr) {
       pull_number,
     });
 
+    // If checks already passed, enablePullRequestAutoMerge fails with
+    // "Pull request is in clean status". Fall back to a direct merge.
+    if (pr.mergeable_state === 'clean' || pr.mergeable_state === 'unstable') {
+      await octokit.rest.pulls.merge({
+        owner: OWNER,
+        repo: REPO,
+        pull_number,
+        merge_method: method,
+      });
+      console.log(
+        JSON.stringify(
+          { merged: true, method: 'direct', mergeable_state: pr.mergeable_state },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
     const mergeMethodGql = method.toUpperCase();
 
     await octokit.graphql(
@@ -1254,6 +1273,54 @@ async function runCancel(octokit, runStr) {
   console.log(JSON.stringify({ id: run_id, message: 'Run cancelled' }, null, 2));
 }
 
+/**
+ * Poll a workflow run until it reaches 'completed' status, then print the result.
+ * @param {import('octokit').Octokit} octokit
+ * @param {string} runStr - Run ID as a string from argv.
+ */
+async function runWait(octokit, runStr) {
+  const run_id = parseIntArg(runStr, 'run ID');
+  const timeout = parseInt(getArg('--timeout') ?? '300', 10);
+  const interval = parseInt(getArg('--interval') ?? '10', 10);
+  const format = getArg('--format') ?? 'table';
+  const deadline = Date.now() + timeout * 1000;
+
+  while (Date.now() < deadline) {
+    const { data } = await octokit.rest.actions.getWorkflowRun({
+      owner: OWNER,
+      repo: REPO,
+      run_id,
+    });
+
+    if (data.status === 'completed') {
+      if (format === 'json') {
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        const COL = { STATUS: 12, CONCLUSION: 12, BRANCH: 50, ID: 14 };
+        const pad = (s, n) =>
+          String(s ?? '')
+            .slice(0, n)
+            .padEnd(n);
+        const header = `${'STATUS'.padEnd(COL.STATUS)}  ${'CONCLUSION'.padEnd(COL.CONCLUSION)}  ${'BRANCH'.padEnd(COL.BRANCH)}  ID`;
+        const divider = '-'.repeat(header.length);
+        console.log(header);
+        console.log(divider);
+        console.log(
+          `${pad(data.status, COL.STATUS)}  ${pad(data.conclusion ?? '', COL.CONCLUSION)}  ${pad(data.head_branch, COL.BRANCH)}  ${data.id}`,
+        );
+      }
+
+      const successConclusions = ['success', 'skipped', 'neutral'];
+      process.exit(successConclusions.includes(data.conclusion) ? 0 : 1);
+    }
+
+    await new Promise((r) => setTimeout(r, interval * 1000));
+  }
+
+  console.error(`Timed out waiting for run ${run_id} after ${timeout}s`);
+  process.exit(2);
+}
+
 // ---------------------------------------------------------------------------
 // Dispatch
 // ---------------------------------------------------------------------------
@@ -1296,7 +1363,8 @@ async function main() {
         '  run view <run-id>\n' +
         '  run rerun <run-id> [--failed-only]\n' +
         '  run logs <run-id>\n' +
-        '  run cancel <run-id>',
+        '  run cancel <run-id>\n' +
+        '  run wait <run-id> [--timeout 300] [--interval 10] [--format table|json]',
     );
     process.exit(1);
   }
@@ -1508,6 +1576,13 @@ async function main() {
         process.exit(1);
       }
       await runCancel(octokit, runStr);
+    } else if (action === 'wait') {
+      const [runStr] = rest;
+      if (!runStr) {
+        console.error('ERROR: run wait requires a run ID');
+        process.exit(1);
+      }
+      await runWait(octokit, runStr);
     } else {
       console.error(`ERROR: unknown run action '${action}'`);
       process.exit(1);


### PR DESCRIPTION
## Summary

- `run wait <run-id>` polls a CI run until `status === 'completed'`, then prints the result in table or JSON format and exits with code 0 (success), 1 (failure conclusion), or 2 (timeout)
- `pr merge --auto` now checks `mergeable_state` before calling `enablePullRequestAutoMerge`; if the PR is already in `clean` or `unstable` state it falls back to a direct REST merge, avoiding the GraphQL error "Pull request is in clean status"

## Test plan

- [x] Manual test: `node .claude/scripts/gh-api.cjs run wait 22917343542 --timeout 10` — returned immediately with table output, exit 0
- [x] `pnpm run lint` — 31 files checked, zero errors
- [x] `pnpm test` — 304 tests passed across 7 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to view detailed pull request information with optional JSON field filtering
  * Introduced workflow run monitoring with customizable timeout and polling intervals
  * Enhanced pull request and workflow run listing with optional tabular output format
  * Improved PR merge workflow with direct-merge fallback for clean/unstable states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->